### PR TITLE
add mailer configurations

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,5 @@
+require Rails.root.join("config/smtp_settings")
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -26,8 +28,14 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.perform_deliveries = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = SMTP_SETTINGS
+  config.action_mailer.default_options = {
+    from: "info@railsgirls-signup.herokuapp.com",
+    host: "localhost:3000"
+  }
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+require Rails.root.join("config/smtp_settings")
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -60,7 +62,13 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_options = {
+    from: "info@railsgirls-signup.herokuapp.com",
+    host: 'railsgirls-signup.herokuapp.com'
+  }
 
+  config.action_mailer.smtp_settings = SMTP_SETTINGS
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true

--- a/config/smtp_settings.rb
+++ b/config/smtp_settings.rb
@@ -1,0 +1,8 @@
+SMTP_SETTINGS = {
+  address:        'smtp.sendgrid.net',
+  port:           '587',
+  authentication: :plain,
+  user_name:      ENV['SENDGRID_USERNAME'],
+  password:       ENV['SENDGRID_PASSWORD'],
+  domain:         'heroku.com'
+}


### PR DESCRIPTION
This PR adds mailer config for Sendgrid ESP to facilitate sending password recovery emails. The current setup for devise works fine and with this ESP config, users should be able to request and receive password recovery emails.